### PR TITLE
Standardize names

### DIFF
--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -30,7 +30,7 @@ The following entity resources are ingested when the integration runs:
 | Project Folder                      | `feroot_project_folder`    | `Group`               |
 | Inspector Project                   | `feroot_project`           | `Project`             |
 | PageGuard Project                   | `feroot_pageguard_project` | `Project`             |
-| Alert                               | `feroot_alert`             | `Incident`            |
+| Alert                               | `feroot_alert`             | `Finding`             |
 | Target Host [\*](#target-host-note) | `host`                     | `Host`                |
 
 <a name="target-host-note">\*</a>`Target Host` entities are generated only if
@@ -46,5 +46,5 @@ The following relationships are created/mapped:
 | `feroot_user_group`     | **HAS**       | `feroot_project_folder`    |
 | `feroot_project`        | **MONITORS**  | `Host`                     |
 | `feroot_project_folder` | **HAS**       | `feroot_project`           |
-| `feroot_project`        | **INCLUDES**  | `feroot_pageguard_project` |
+| `feroot_project`        | **CONTAINS**  | `feroot_pageguard_project` |
 | `feroot_project`        | **GENERATED** | `feroot_alert`             |

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,1 +1,2 @@
+process.env.ENABLE_GRAPH_OBJECT_SCHEMA_VALIDATION = '1';
 module.exports = require('@jupiterone/integration-sdk-dev-tools/config/jest');

--- a/package.json
+++ b/package.json
@@ -27,12 +27,12 @@
     "prepack": "yarn build"
   },
   "peerDependencies": {
-    "@jupiterone/integration-sdk-core": "^2.3.0"
+    "@jupiterone/integration-sdk-core": "^2.10.0"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-core": "^2.3.0",
-    "@jupiterone/integration-sdk-dev-tools": "^2.3.0",
-    "@jupiterone/integration-sdk-testing": "^2.3.0"
+    "@jupiterone/integration-sdk-core": "^2.10.0",
+    "@jupiterone/integration-sdk-dev-tools": "^2.10.0",
+    "@jupiterone/integration-sdk-testing": "^2.10.0"
   },
   "dependencies": {
     "@types/request-promise-native": "^1.0.17",

--- a/src/steps/fetchAlerts.test.ts
+++ b/src/steps/fetchAlerts.test.ts
@@ -51,16 +51,16 @@ describe('Alerts fetching', () => {
       {
         alertType: 'alert-type',
         eventsCount: 1,
-        id: 'abc',
-        projectUuid: 'zzz',
+        id: 'alert-uuid-1',
+        projectUuid: 'project-uuid-1',
         state: 1,
         title: 'Some alert',
       },
       {
         alertType: 'alert-type-2',
         eventsCount: 2,
-        id: 'abc2',
-        projectUuid: 'zzz2',
+        id: 'alert-uuid-2',
+        projectUuid: 'project-uuid-2',
         state: 2,
         title: 'Some alert 2',
       },
@@ -78,17 +78,17 @@ describe('Alerts fetching', () => {
 
     expect(context.jobState.collectedEntities).toMatchObject([
       {
-        id: 'abc',
+        id: 'alert-uuid-1',
         _type: 'feroot_alert',
         _class: ['Finding'],
-        _key: 'abc',
+        _key: 'alert-uuid-1',
         name: 'alert-type',
         category: 'Feroot Alert',
         severity: 'major',
         reportable: true,
         displayName: 'Some alert',
         eventsCount: 1,
-        active: true,
+        open: true,
         _rawData: [
           {
             name: 'default',
@@ -97,17 +97,17 @@ describe('Alerts fetching', () => {
         ],
       },
       {
-        id: 'abc2',
+        id: 'alert-uuid-2',
         _type: 'feroot_alert',
         _class: ['Finding'],
-        _key: 'abc2',
+        _key: 'alert-uuid-2',
         name: 'alert-type-2',
         category: 'Feroot Alert',
         severity: 'major',
         reportable: true,
         displayName: 'Some alert 2',
         eventsCount: 2,
-        active: false,
+        open: false,
         _rawData: [
           {
             name: 'default',
@@ -118,19 +118,19 @@ describe('Alerts fetching', () => {
     ]);
     expect(context.jobState.collectedRelationships).toMatchObject([
       {
-        _key: 'zzz|generated|abc',
+        _key: 'project-uuid-1|generated|alert-uuid-1',
         _type: 'feroot_project_generated_alert',
         _class: 'GENERATED',
-        _fromEntityKey: 'zzz',
-        _toEntityKey: 'abc',
+        _fromEntityKey: 'project-uuid-1',
+        _toEntityKey: 'alert-uuid-1',
         displayName: 'GENERATED',
       },
       {
-        _key: 'zzz2|generated|abc2',
+        _key: 'project-uuid-2|generated|alert-uuid-2',
         _type: 'feroot_project_generated_alert',
         _class: 'GENERATED',
-        _fromEntityKey: 'zzz2',
-        _toEntityKey: 'abc2',
+        _fromEntityKey: 'project-uuid-2',
+        _toEntityKey: 'alert-uuid-2',
         displayName: 'GENERATED',
       },
     ]);

--- a/src/steps/fetchAlerts.test.ts
+++ b/src/steps/fetchAlerts.test.ts
@@ -80,7 +80,7 @@ describe('Alerts fetching', () => {
       {
         id: 'abc',
         _type: 'feroot_alert',
-        _class: ['Incident'],
+        _class: ['Finding'],
         _key: 'abc',
         name: 'alert-type',
         category: 'Feroot Alert',
@@ -99,7 +99,7 @@ describe('Alerts fetching', () => {
       {
         id: 'abc2',
         _type: 'feroot_alert',
-        _class: ['Incident'],
+        _class: ['Finding'],
         _key: 'abc2',
         name: 'alert-type-2',
         category: 'Feroot Alert',

--- a/src/steps/fetchAlerts.ts
+++ b/src/steps/fetchAlerts.ts
@@ -26,8 +26,9 @@ const step: IntegrationStep<IntegrationConfig> = {
               source: alert,
               assign: {
                 _type: 'feroot_alert',
-                _class: 'Incident',
+                _class: 'Finding',
                 _key: alert.id,
+                id: alert.id,
                 name: alert.alertType || 'unknown-alert',
                 category: 'Feroot Alert',
                 severity: 'major',

--- a/src/steps/fetchAlerts.ts
+++ b/src/steps/fetchAlerts.ts
@@ -36,7 +36,7 @@ const step: IntegrationStep<IntegrationConfig> = {
 
                 displayName: alert.title,
                 eventsCount: alert.eventsCount,
-                active: alert.state === 1,
+                open: alert.state === 1,
               },
             },
           }),

--- a/src/steps/fetchPageguardProjects.test.ts
+++ b/src/steps/fetchPageguardProjects.test.ts
@@ -11,13 +11,13 @@ describe('PageGuard Projects fetching', () => {
       {
         id: 'abc',
         name: 'name-1',
-        uuid: 'uuid-1',
+        uuid: 'project-uuid-1',
         activatedAt: 1597167323436,
       },
       {
         id: 'abc-2',
         name: 'name-2',
-        uuid: 'uuid-2',
+        uuid: 'project-uuid-2',
         activatedAt: 1597166323436,
       },
     ];
@@ -38,7 +38,7 @@ describe('PageGuard Projects fetching', () => {
         name: 'name-1',
         _type: 'feroot_pageguard_project',
         _class: ['Project'],
-        _key: 'pg:uuid-1',
+        _key: 'pg:project-uuid-1',
         displayName: 'name-1',
         activatedAt: 1597167323436,
         active: true,
@@ -54,7 +54,7 @@ describe('PageGuard Projects fetching', () => {
         name: 'name-2',
         _type: 'feroot_pageguard_project',
         _class: ['Project'],
-        _key: 'pg:uuid-2',
+        _key: 'pg:project-uuid-2',
         displayName: 'name-2',
         activatedAt: 1597166323436,
         active: true,

--- a/src/steps/fetchProjectFolders.test.ts
+++ b/src/steps/fetchProjectFolders.test.ts
@@ -11,14 +11,14 @@ describe('Project Folders fetching', () => {
       {
         id: 'abc',
         name: 'name-1',
-        uuid: 'uuid-1',
+        uuid: 'folder-uuid-1',
         userGroups: [],
       },
       {
         id: 'abc-2',
         name: 'name-2',
-        uuid: 'uuid-2',
-        userGroups: ['uuid-g1', 'uuid-g2'],
+        uuid: 'folder-uuid-2',
+        userGroups: ['group-uuid-1', 'group-uuid-2'],
       },
     ];
 
@@ -38,7 +38,7 @@ describe('Project Folders fetching', () => {
         name: 'name-1',
         _type: 'feroot_project_folder',
         _class: ['Group'],
-        _key: 'uuid-1',
+        _key: 'folder-uuid-1',
         displayName: 'name-1',
         _rawData: [
           {
@@ -52,7 +52,7 @@ describe('Project Folders fetching', () => {
         name: 'name-2',
         _type: 'feroot_project_folder',
         _class: ['Group'],
-        _key: 'uuid-2',
+        _key: 'folder-uuid-2',
         displayName: 'name-2',
         _rawData: [
           {
@@ -64,19 +64,19 @@ describe('Project Folders fetching', () => {
     ]);
     expect(context.jobState.collectedRelationships).toMatchObject([
       {
-        _key: 'uuid-g1|has|uuid-2',
+        _key: 'group-uuid-1|has|folder-uuid-2',
         _type: 'feroot_user_group_has_project_folder',
         _class: 'HAS',
-        _fromEntityKey: 'uuid-g1',
-        _toEntityKey: 'uuid-2',
+        _fromEntityKey: 'group-uuid-1',
+        _toEntityKey: 'folder-uuid-2',
         displayName: 'HAS',
       },
       {
-        _key: 'uuid-g2|has|uuid-2',
+        _key: 'group-uuid-2|has|folder-uuid-2',
         _type: 'feroot_user_group_has_project_folder',
         _class: 'HAS',
-        _fromEntityKey: 'uuid-g2',
-        _toEntityKey: 'uuid-2',
+        _fromEntityKey: 'group-uuid-2',
+        _toEntityKey: 'folder-uuid-2',
         displayName: 'HAS',
       },
     ]);

--- a/src/steps/fetchProjects.test.ts
+++ b/src/steps/fetchProjects.test.ts
@@ -11,20 +11,20 @@ describe('Projects fetching', () => {
       {
         id: 'abc',
         name: 'name-1',
-        serviceUuid: 'service-1',
+        serviceUuid: 'service-uuid-1',
         status: 1,
         urls: ['https://www.feroot.com', 'https://app.feroot.com'],
-        uuid: 'uuid-1',
+        uuid: 'project-uuid-1',
       },
       {
         id: 'abc-2',
         name: 'name-2',
-        serviceUuid: 'service-1',
+        serviceUuid: 'service-uuid-1',
         status: 3, // paused
         urls: ['https://www.google.com'],
-        uuid: 'uuid-2',
-        pageguardUuid: 'pg-uuid-1',
-        projectGroup: 'uuid-g1',
+        uuid: 'project-uuid-2',
+        pageguardUuid: 'pageguard-uuid-1',
+        projectGroup: 'group-uuid-1',
       },
     ];
 
@@ -50,7 +50,7 @@ describe('Projects fetching', () => {
         status: 'Active',
         _type: 'feroot_project',
         _class: ['Project'],
-        _key: 'uuid-1',
+        _key: 'project-uuid-1',
         displayName: 'name-1',
         active: true,
         urls: ['https://www.feroot.com', 'https://app.feroot.com'],
@@ -67,7 +67,7 @@ describe('Projects fetching', () => {
         status: 'Paused',
         _type: 'feroot_project',
         _class: ['Project'],
-        _key: 'uuid-2',
+        _key: 'project-uuid-2',
         displayName: 'name-2',
         active: false,
         urls: ['https://www.google.com'],
@@ -84,7 +84,7 @@ describe('Projects fetching', () => {
         _class: 'MONITORS',
         _mapping: {
           relationshipDirection: 'FORWARD',
-          sourceEntityKey: 'uuid-1',
+          sourceEntityKey: 'project-uuid-1',
           targetFilterKeys: [['_class', 'hostname']],
           targetEntity: {
             _class: 'Host',
@@ -95,14 +95,15 @@ describe('Projects fetching', () => {
           skipTargetCreation: true,
         },
         displayName: 'MONITORS',
-        _key: 'uuid-1|monitors|FORWARD:_class=Host:hostname=www.feroot.com',
+        _key:
+          'project-uuid-1|monitors|FORWARD:_class=Host:hostname=www.feroot.com',
         _type: 'feroot_project_monitors_host',
       },
       {
         _class: 'MONITORS',
         _mapping: {
           relationshipDirection: 'FORWARD',
-          sourceEntityKey: 'uuid-2',
+          sourceEntityKey: 'project-uuid-2',
           targetFilterKeys: [['_class', 'hostname']],
           targetEntity: {
             _class: 'Host',
@@ -113,23 +114,24 @@ describe('Projects fetching', () => {
           skipTargetCreation: true,
         },
         displayName: 'MONITORS',
-        _key: 'uuid-2|monitors|FORWARD:_class=Host:hostname=www.google.com',
+        _key:
+          'project-uuid-2|monitors|FORWARD:_class=Host:hostname=www.google.com',
         _type: 'feroot_project_monitors_host',
       },
       {
-        _key: 'uuid-g1|has|uuid-2',
+        _key: 'group-uuid-1|has|project-uuid-2',
         _type: 'feroot_project_folder_has_project',
         _class: 'HAS',
-        _fromEntityKey: 'uuid-g1',
-        _toEntityKey: 'uuid-2',
+        _fromEntityKey: 'group-uuid-1',
+        _toEntityKey: 'project-uuid-2',
         displayName: 'HAS',
       },
       {
-        _key: 'uuid-2|contains|pg:pg-uuid-1',
+        _key: 'project-uuid-2|contains|pg:pageguard-uuid-1',
         _type: 'feroot_project_contains_pageguard_project',
         _class: 'CONTAINS',
-        _fromEntityKey: 'uuid-2',
-        _toEntityKey: 'pg:pg-uuid-1',
+        _fromEntityKey: 'project-uuid-2',
+        _toEntityKey: 'pg:pageguard-uuid-1',
         displayName: 'CONTAINS',
       },
     ]);
@@ -140,10 +142,10 @@ describe('Projects fetching', () => {
       {
         id: 'abc',
         name: 'name-1',
-        serviceUuid: 'service-1',
+        serviceUuid: 'service-uuid-1',
         status: 1,
         urls: ['https://www.feroot.com'],
-        uuid: 'uuid-1',
+        uuid: 'project-uuid-1',
       },
     ];
 
@@ -168,7 +170,7 @@ describe('Projects fetching', () => {
         _class: 'MONITORS',
         _mapping: {
           relationshipDirection: 'FORWARD',
-          sourceEntityKey: 'uuid-1',
+          sourceEntityKey: 'project-uuid-1',
           targetFilterKeys: [['_class', 'hostname']],
           targetEntity: {
             _class: 'Host',
@@ -179,7 +181,8 @@ describe('Projects fetching', () => {
           skipTargetCreation: false,
         },
         displayName: 'MONITORS',
-        _key: 'uuid-1|monitors|FORWARD:_class=Host:hostname=www.feroot.com',
+        _key:
+          'project-uuid-1|monitors|FORWARD:_class=Host:hostname=www.feroot.com',
         _type: 'feroot_project_monitors_host',
       },
     ]);

--- a/src/steps/fetchProjects.test.ts
+++ b/src/steps/fetchProjects.test.ts
@@ -125,12 +125,12 @@ describe('Projects fetching', () => {
         displayName: 'HAS',
       },
       {
-        _key: 'uuid-2|includes|pg:pg-uuid-1',
-        _type: 'feroot_project_includes_pageguard_project',
-        _class: 'INCLUDES',
+        _key: 'uuid-2|contains|pg:pg-uuid-1',
+        _type: 'feroot_project_contains_pageguard_project',
+        _class: 'CONTAINS',
         _fromEntityKey: 'uuid-2',
         _toEntityKey: 'pg:pg-uuid-1',
-        displayName: 'INCLUDES',
+        displayName: 'CONTAINS',
       },
     ]);
   });

--- a/src/steps/fetchProjects.ts
+++ b/src/steps/fetchProjects.ts
@@ -59,9 +59,9 @@ const step: IntegrationStep<IntegrationConfig> = {
       await jobState.addRelationship(
         createIntegrationRelationship({
           _class: 'MONITORS',
-          _type: 'feroot_project_monitors_host',
           _mapping: {
             relationshipDirection: RelationshipDirection.FORWARD,
+            sourceEntityType: 'feroot_project',
             sourceEntityKey: project.uuid,
             targetFilterKeys: [['_class', 'hostname']],
             targetEntity: {
@@ -90,7 +90,7 @@ const step: IntegrationStep<IntegrationConfig> = {
       if (project.pageguardUuid) {
         await jobState.addRelationship(
           createIntegrationRelationship({
-            _class: 'INCLUDES',
+            _class: 'CONTAINS',
             fromKey: project.uuid,
             fromType: 'feroot_project',
             toKey: `pg:${project.pageguardUuid}`,

--- a/src/steps/fetchUserGroups.test.ts
+++ b/src/steps/fetchUserGroups.test.ts
@@ -11,12 +11,12 @@ describe('User Groups fetching', () => {
       {
         id: 'abc',
         name: 'name-1',
-        uuid: 'uuid-1',
+        uuid: 'usergroup-uuid-1',
       },
       {
         id: 'abc-2',
         name: 'name-2',
-        uuid: 'uuid-2',
+        uuid: 'usergroup-uuid-2',
       },
     ];
 
@@ -36,7 +36,7 @@ describe('User Groups fetching', () => {
         name: 'name-1',
         _type: 'feroot_user_group',
         _class: ['UserGroup'],
-        _key: 'uuid-1',
+        _key: 'usergroup-uuid-1',
         displayName: 'name-1',
         _rawData: [
           {
@@ -50,7 +50,7 @@ describe('User Groups fetching', () => {
         name: 'name-2',
         _type: 'feroot_user_group',
         _class: ['UserGroup'],
-        _key: 'uuid-2',
+        _key: 'usergroup-uuid-2',
         displayName: 'name-2',
         _rawData: [
           {

--- a/src/steps/fetchUsers.test.ts
+++ b/src/steps/fetchUsers.test.ts
@@ -16,7 +16,7 @@ describe('User Groups fetching', () => {
         phone: '123',
         roles: ['admin', 'owner'],
         userGroups: [],
-        uuid: 'uuid-1',
+        uuid: 'user-uuid-1',
       },
       {
         id: 'abc-2',
@@ -25,8 +25,8 @@ describe('User Groups fetching', () => {
         lastName: 'Smith',
         phone: '',
         roles: [],
-        userGroups: ['uuid-g1', 'uuid-g2'],
-        uuid: 'uuid-2',
+        userGroups: ['usergroup-uuid-1', 'usergroup-uuid-2'],
+        uuid: 'user-uuid-2',
       },
     ];
 
@@ -46,7 +46,7 @@ describe('User Groups fetching', () => {
         email: 'user@gmail.com',
         _type: 'feroot_user',
         _class: ['User'],
-        _key: 'uuid-1',
+        _key: 'user-uuid-1',
         displayName: 'John Doe',
         name: 'user@gmail.com',
         username: 'user@gmail.com',
@@ -62,7 +62,7 @@ describe('User Groups fetching', () => {
         email: 'user2@gmail.com',
         _type: 'feroot_user',
         _class: ['User'],
-        _key: 'uuid-2',
+        _key: 'user-uuid-2',
         displayName: 'Daniel Smith',
         name: 'user2@gmail.com',
         username: 'user2@gmail.com',
@@ -77,19 +77,19 @@ describe('User Groups fetching', () => {
 
     expect(context.jobState.collectedRelationships).toMatchObject([
       {
-        _key: 'uuid-g1|has|uuid-2',
+        _key: 'usergroup-uuid-1|has|user-uuid-2',
         _type: 'feroot_user_group_has_user',
         _class: 'HAS',
-        _fromEntityKey: 'uuid-g1',
-        _toEntityKey: 'uuid-2',
+        _fromEntityKey: 'usergroup-uuid-1',
+        _toEntityKey: 'user-uuid-2',
         displayName: 'HAS',
       },
       {
-        _key: 'uuid-g2|has|uuid-2',
+        _key: 'usergroup-uuid-2|has|user-uuid-2',
         _type: 'feroot_user_group_has_user',
         _class: 'HAS',
-        _fromEntityKey: 'uuid-g2',
-        _toEntityKey: 'uuid-2',
+        _fromEntityKey: 'usergroup-uuid-2',
+        _toEntityKey: 'user-uuid-2',
         displayName: 'HAS',
       },
     ]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -464,39 +464,41 @@
   dependencies:
     ajv "^6.12.0"
 
-"@jupiterone/integration-sdk-cli@^2.3.0":
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-cli/-/integration-sdk-cli-2.3.0.tgz#de4372d7cf337e202aaeaa291cd6edddfb570863"
-  integrity sha512-6EMt2n1YbBh/8g7ZCEPLz47rx2trp9kqWtziDRb6gMyfyDzwd+MCcQvTQDj4UxdtTQaQ4QUFF9fjsdJp5dVHsg==
+"@jupiterone/integration-sdk-cli@^2.10.0":
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-cli/-/integration-sdk-cli-2.10.0.tgz#07acbada5622e7f8abe63486b32a3252fa89e04c"
+  integrity sha512-QqlqAqR5+rKeEIttfCqWQ5AopDGs44kS3rN5eRYxd8+Rmx17kw0b/z/+78NHKjMKZo0y7DGD6ZQWyZgTixggXg==
   dependencies:
-    "@jupiterone/integration-sdk-runtime" "^2.3.0"
+    "@jupiterone/integration-sdk-runtime" "^2.10.0"
     commander "^5.0.0"
     globby "^11.0.0"
+    lodash "^4.17.19"
     upath "^1.2.0"
     vis "^4.21.0-EOL"
 
-"@jupiterone/integration-sdk-core@^2.3.0":
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-core/-/integration-sdk-core-2.3.0.tgz#804087735c07f761b4e47fef05b85277eb4aa8e0"
-  integrity sha512-LIt3uE8uGUvuygl72UvhcT9b2yQamHq/INgDcg88jbNt7yiGOfTRSoNh+W2x7cYcRMRlZJeH27ySsmbWXYzAYw==
+"@jupiterone/integration-sdk-core@^2.10.0":
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-core/-/integration-sdk-core-2.10.0.tgz#55cb4b41d03093644743750132b29a50e95d4b18"
+  integrity sha512-corDLIygWv+xcY0i/IXk1zHbqiIOM2DloWDC7uG7MjjNO0PyMYzu6vv/lV4lS2cqiBFzLsi3pO0naRStnTtrvA==
   dependencies:
     "@jupiterone/data-model" "^0.7.1"
     lodash "^4.17.15"
     uuid "^7.0.3"
 
-"@jupiterone/integration-sdk-dev-tools@^2.3.0":
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-dev-tools/-/integration-sdk-dev-tools-2.3.0.tgz#b5914a6bea137baf44c2f63b75b81662c7046367"
-  integrity sha512-amOwliz1dRpBePLq23Qskjh6IWAPmIOxLRK/N+e3ol3vcEC8K39XGW2/sNJ4iScteIMpPyZ8AMkTfEjawR70/A==
+"@jupiterone/integration-sdk-dev-tools@^2.10.0":
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-dev-tools/-/integration-sdk-dev-tools-2.10.0.tgz#a75f3b841e6adfaf50d17d2b08cb32a2cc7a4b47"
+  integrity sha512-RFu5YmYRnPQSrE1ehE7fHF7WdssW98kb7kYn9o5AI0uqjKazg4va1U+n0Ikyk0xB/mOkvYZ/80IoWG067Jm49A==
   dependencies:
-    "@jupiterone/integration-sdk-cli" "^2.3.0"
+    "@jupiterone/integration-sdk-cli" "^2.10.0"
+    "@jupiterone/integration-sdk-testing" "^2.10.0"
     "@types/jest" "^25.2.3"
     "@types/node" "^14.0.5"
-    "@typescript-eslint/eslint-plugin" "^3.0.2"
-    "@typescript-eslint/parser" "^3.0.2"
-    eslint "^7.1.0"
+    "@typescript-eslint/eslint-plugin" "^3.8.0"
+    "@typescript-eslint/parser" "^3.8.0"
+    eslint "^7.6.0"
     eslint-config-prettier "^6.11.0"
-    eslint-plugin-jest "^23.13.2"
+    eslint-plugin-jest "^23.20.0"
     husky "^4.2.5"
     jest "^26.0.1"
     lint-staged "^10.2.6"
@@ -505,12 +507,12 @@
     ts-node "^8.10.2"
     typescript "^3.9.3"
 
-"@jupiterone/integration-sdk-runtime@^2.3.0":
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-runtime/-/integration-sdk-runtime-2.3.0.tgz#e7d6b604a322df86ba536058c9c243be23798d8e"
-  integrity sha512-n1yB0b/Ek1GPZuKH8mNO66Xuu8AhbhYLIs2pECJfIoHFs4xwyyO6xuiM8MglDfUNdagRmVs7aQQvqbFJe5KuvQ==
+"@jupiterone/integration-sdk-runtime@^2.10.0":
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-runtime/-/integration-sdk-runtime-2.10.0.tgz#1c9081cea26a43ae766c2a8dcf71baa65b26c877"
+  integrity sha512-VyNm3mAHbF2t537cs+LCMi6xcZCSiErGGQhV2K8c7xrU/eNl8OwJ/+KRLUackNl5TNoawQnjtkJ5pcIJ0DvfVg==
   dependencies:
-    "@jupiterone/integration-sdk-core" "^2.3.0"
+    "@jupiterone/integration-sdk-core" "^2.10.0"
     "@lifeomic/alpha" "^1.1.3"
     async-sema "^3.1.0"
     axios "^0.19.2"
@@ -519,6 +521,7 @@
     dependency-graph "^0.9.0"
     dotenv "^8.2.0"
     dotenv-expand "^5.1.0"
+    get-folder-size "^2.0.1"
     globby "^11.0.0"
     jsonwebtoken "^8.5.1"
     lodash "^4.17.15"
@@ -527,13 +530,13 @@
     rimraf "^3.0.2"
     uuid "^7.0.3"
 
-"@jupiterone/integration-sdk-testing@^2.3.0":
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-testing/-/integration-sdk-testing-2.3.0.tgz#e0464159f4acb4b22f712ceb081392523808cbef"
-  integrity sha512-NCdT/21on5rGugHDPa1SsM7EPOcDYq1Ob57zsZvO7gVBD9uBOLJGlrJJ3+svkZokO04DCLB3IY1uZwtKV/tgow==
+"@jupiterone/integration-sdk-testing@^2.10.0":
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-testing/-/integration-sdk-testing-2.10.0.tgz#6a863c2b3ffcea452e2e45436297b2519833e73a"
+  integrity sha512-9jMxp8rLnqBdQBVyyDfMow94M5CvzLPGGxWGDeMUV5GBPi4zGt/pMF4J+DDy2uggpohjdgifMU3fAKkHqw0GQQ==
   dependencies:
-    "@jupiterone/integration-sdk-core" "^2.3.0"
-    "@jupiterone/integration-sdk-runtime" "^2.3.0"
+    "@jupiterone/integration-sdk-core" "^2.10.0"
+    "@jupiterone/integration-sdk-runtime" "^2.10.0"
     "@pollyjs/adapter-node-http" "^4.0.4"
     "@pollyjs/core" "^4.0.4"
     "@pollyjs/persister-fs" "^4.0.4"
@@ -541,6 +544,7 @@
     "@types/pollyjs__adapter-node-http" "^2.0.0"
     "@types/pollyjs__core" "^4.0.0"
     "@types/pollyjs__persister" "^2.0.1"
+    deepmerge "^4.2.2"
     lodash "^4.17.15"
 
 "@lifeomic/alpha@^1.1.3":
@@ -858,24 +862,26 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@typescript-eslint/eslint-plugin@^3.0.2":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-3.1.0.tgz#4ac00ecca3bbea740c577f1843bc54fa69c3def2"
-  integrity sha512-D52KwdgkjYc+fmTZKW7CZpH5ZBJREJKZXRrveMiRCmlzZ+Rw9wRVJ1JAmHQ9b/+Ehy1ZeaylofDB9wwXUt83wg==
+"@typescript-eslint/eslint-plugin@^3.8.0":
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-3.9.0.tgz#0fe529b33d63c9a94f7503ca2bb12c84b9477ff3"
+  integrity sha512-UD6b4p0/hSe1xdTvRCENSx7iQ+KR6ourlZFfYuPC7FlXEzdHuLPrEmuxZ23b2zW96KJX9Z3w05GE/wNOiEzrVg==
   dependencies:
-    "@typescript-eslint/experimental-utils" "3.1.0"
+    "@typescript-eslint/experimental-utils" "3.9.0"
+    debug "^4.1.1"
     functional-red-black-tree "^1.0.1"
     regexpp "^3.0.0"
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@typescript-eslint/experimental-utils@3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-3.1.0.tgz#2d5dba7c2ac2a3da3bfa3f461ff64de38587a872"
-  integrity sha512-Zf8JVC2K1svqPIk1CB/ehCiWPaERJBBokbMfNTNRczCbQSlQXaXtO/7OfYz9wZaecNvdSvVADt6/XQuIxhC79w==
+"@typescript-eslint/experimental-utils@3.9.0":
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-3.9.0.tgz#3171d8ddba0bf02a8c2034188593630914fcf5ee"
+  integrity sha512-/vSHUDYizSOhrOJdjYxPNGfb4a3ibO8zd4nUKo/QBFOmxosT3cVUV7KIg8Dwi6TXlr667G7YPqFK9+VSZOorNA==
   dependencies:
     "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/typescript-estree" "3.1.0"
+    "@typescript-eslint/types" "3.9.0"
+    "@typescript-eslint/typescript-estree" "3.9.0"
     eslint-scope "^5.0.0"
     eslint-utils "^2.0.0"
 
@@ -889,15 +895,21 @@
     eslint-scope "^5.0.0"
     eslint-utils "^2.0.0"
 
-"@typescript-eslint/parser@^3.0.2":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-3.1.0.tgz#9c02ba5d88ad2355672f39e6cd4176f172dd47f8"
-  integrity sha512-NcDSJK8qTA2tPfyGiPes9HtVKLbksmuYjlgGAUs7Ld2K0swdWibnCq9IJx9kJN8JJdgUJSorFiGaPHBgH81F/Q==
+"@typescript-eslint/parser@^3.8.0":
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-3.9.0.tgz#344978a265d9a5c7c8f13e62c78172a4374dabea"
+  integrity sha512-rDHOKb6uW2jZkHQniUQVZkixQrfsZGUCNWWbKWep4A5hGhN5dLHMUCNAWnC4tXRlHedXkTDptIpxs6e4Pz8UfA==
   dependencies:
     "@types/eslint-visitor-keys" "^1.0.0"
-    "@typescript-eslint/experimental-utils" "3.1.0"
-    "@typescript-eslint/typescript-estree" "3.1.0"
+    "@typescript-eslint/experimental-utils" "3.9.0"
+    "@typescript-eslint/types" "3.9.0"
+    "@typescript-eslint/typescript-estree" "3.9.0"
     eslint-visitor-keys "^1.1.0"
+
+"@typescript-eslint/types@3.9.0":
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-3.9.0.tgz#be9d0aa451e1bf3ce99f2e6920659e5b2e6bfe18"
+  integrity sha512-rb6LDr+dk9RVVXO/NJE8dT1pGlso3voNdEIN8ugm4CWM5w5GimbThCMiMl4da1t5u3YwPWEwOnKAULCZgBtBHg==
 
 "@typescript-eslint/typescript-estree@2.34.0":
   version "2.34.0"
@@ -912,18 +924,26 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@typescript-eslint/typescript-estree@3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-3.1.0.tgz#eaff52d31e615e05b894f8b9d2c3d8af152a5dd2"
-  integrity sha512-+4nfYauqeQvK55PgFrmBWFVYb6IskLyOosYEmhH3mSVhfBp9AIJnjExdgDmKWoOBHRcPM8Ihfm2BFpZf0euUZQ==
+"@typescript-eslint/typescript-estree@3.9.0":
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-3.9.0.tgz#c6abbb50fa0d715cab46fef67ca6378bf2eaca13"
+  integrity sha512-N+158NKgN4rOmWVfvKOMoMFV5n8XxAliaKkArm/sOypzQ0bUL8MSnOEBW3VFIeffb/K5ce/cAV0yYhR7U4ALAA==
   dependencies:
+    "@typescript-eslint/types" "3.9.0"
+    "@typescript-eslint/visitor-keys" "3.9.0"
     debug "^4.1.1"
-    eslint-visitor-keys "^1.1.0"
     glob "^7.1.6"
     is-glob "^4.0.1"
     lodash "^4.17.15"
     semver "^7.3.2"
     tsutils "^3.17.1"
+
+"@typescript-eslint/visitor-keys@3.9.0":
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-3.9.0.tgz#44de8e1b1df67adaf3b94d6b60b80f8faebc8dd3"
+  integrity sha512-O1qeoGqDbu0EZUC/MZ6F1WHTIzcBVhGqDj3LhTnj65WUA548RXVxUHbYhAW9bZWfb2rnX9QsbbP5nmeJ5Z4+ng==
+  dependencies:
+    eslint-visitor-keys "^1.1.0"
 
 abab@^2.0.3:
   version "2.0.3"
@@ -956,10 +976,15 @@ acorn-walk@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.1.1.tgz#345f0dffad5c735e7373d2fec9a1023e6a44b83e"
   integrity sha512-wdlPY2tm/9XBr7QkKlq0WQVgiuGTX6YWPyRyBviSoScBuLfTVQhvwg6wJ369GJ/1nPfTLMfnrFIfjqVg6d+jQQ==
 
-acorn@^7.1.1, acorn@^7.2.0:
+acorn@^7.1.1:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.2.0.tgz#17ea7e40d7c8640ff54a694c889c26f31704effe"
   integrity sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ==
+
+acorn@^7.3.1:
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.0.tgz#e1ad486e6c54501634c6c397c5c121daa383607c"
+  integrity sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==
 
 aggregate-error@^3.0.0:
   version "3.0.1"
@@ -1444,11 +1469,6 @@ char-regex@^1.0.2:
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
   integrity sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==
 
-chardet@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
-  integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
-
 ci-info@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
@@ -1483,11 +1503,6 @@ cli-truncate@2.1.0, cli-truncate@^2.1.0:
   dependencies:
     slice-ansi "^3.0.0"
     string-width "^4.2.0"
-
-cli-width@^2.0.0:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.1.tgz#b0433d0b4e9c847ef18868a4ef16fd5fc8271c48"
-  integrity sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==
 
 cliui@^6.0.0:
   version "6.0.0"
@@ -1944,14 +1959,14 @@ eslint-config-prettier@^6.11.0:
   dependencies:
     get-stdin "^6.0.0"
 
-eslint-plugin-jest@^23.13.2:
-  version "23.13.2"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-23.13.2.tgz#7b7993b4e09be708c696b02555083ddefd7e4cc7"
-  integrity sha512-qZit+moTXTyZFNDqSIR88/L3rdBlTU7CuW6XmyErD2FfHEkdoLgThkRbiQjzgYnX6rfgLx3Ci4eJmF4Ui5v1Cw==
+eslint-plugin-jest@^23.20.0:
+  version "23.20.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-23.20.0.tgz#e1d69c75f639e99d836642453c4e75ed22da4099"
+  integrity sha512-+6BGQt85OREevBDWCvhqj1yYA4+BFK4XnRZSGJionuEYmcglMZYLNNBBemwzbqUAckURaHdJSBcjHPyrtypZOw==
   dependencies:
     "@typescript-eslint/experimental-utils" "^2.5.0"
 
-eslint-scope@^5.0.0:
+eslint-scope@^5.0.0, eslint-scope@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.0.tgz#d0f971dfe59c69e0cada684b23d49dbf82600ce5"
   integrity sha512-iiGRvtxWqgtx5m8EyQUJihBloE4EnYeGE/bz1wSPwJE6tZuJUtHlhqDM4Xj2ukE8Dyy1+HCZ4hE0fzIVMzb58w==
@@ -1966,15 +1981,27 @@ eslint-utils@^2.0.0:
   dependencies:
     eslint-visitor-keys "^1.1.0"
 
-eslint-visitor-keys@^1.1.0, eslint-visitor-keys@^1.2.0:
+eslint-utils@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-2.1.0.tgz#d2de5e03424e707dc10c74068ddedae708741b27"
+  integrity sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==
+  dependencies:
+    eslint-visitor-keys "^1.1.0"
+
+eslint-visitor-keys@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.2.0.tgz#74415ac884874495f78ec2a97349525344c981fa"
   integrity sha512-WFb4ihckKil6hu3Dp798xdzSfddwKKU3+nGniKF6HfeW6OLd2OUDEPP7TcHtB5+QXOKg2s6B2DaMPE1Nn/kxKQ==
 
-eslint@^7.1.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.1.0.tgz#d9a1df25e5b7859b0a3d86bb05f0940ab676a851"
-  integrity sha512-DfS3b8iHMK5z/YLSme8K5cge168I8j8o1uiVmFCgnnjxZQbCGyraF8bMl7Ju4yfBmCuxD7shOF7eqGkcuIHfsA==
+eslint-visitor-keys@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz#30ebd1ef7c2fdff01c3a4f151044af25fab0523e"
+  integrity sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==
+
+eslint@^7.6.0:
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.6.0.tgz#522d67cfaea09724d96949c70e7a0550614d64d6"
+  integrity sha512-QlAManNtqr7sozWm5TF4wIH9gmUm2hE3vNRUvyoYAa4y1l5/jxD/PQStEjBMQtCqZmSep8UxrcecI60hOpe61w==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     ajv "^6.10.0"
@@ -1982,10 +2009,11 @@ eslint@^7.1.0:
     cross-spawn "^7.0.2"
     debug "^4.0.1"
     doctrine "^3.0.0"
-    eslint-scope "^5.0.0"
-    eslint-utils "^2.0.0"
-    eslint-visitor-keys "^1.1.0"
-    espree "^7.0.0"
+    enquirer "^2.3.5"
+    eslint-scope "^5.1.0"
+    eslint-utils "^2.1.0"
+    eslint-visitor-keys "^1.3.0"
+    espree "^7.2.0"
     esquery "^1.2.0"
     esutils "^2.0.2"
     file-entry-cache "^5.0.1"
@@ -1995,12 +2023,11 @@ eslint@^7.1.0:
     ignore "^4.0.6"
     import-fresh "^3.0.0"
     imurmurhash "^0.1.4"
-    inquirer "^7.0.0"
     is-glob "^4.0.0"
     js-yaml "^3.13.1"
     json-stable-stringify-without-jsonify "^1.0.1"
     levn "^0.4.1"
-    lodash "^4.17.14"
+    lodash "^4.17.19"
     minimatch "^3.0.4"
     natural-compare "^1.4.0"
     optionator "^0.9.1"
@@ -2013,14 +2040,14 @@ eslint@^7.1.0:
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
 
-espree@^7.0.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-7.1.0.tgz#a9c7f18a752056735bf1ba14cb1b70adc3a5ce1c"
-  integrity sha512-dcorZSyfmm4WTuTnE5Y7MEN1DyoPYy1ZR783QW1FJoenn7RailyWFsq/UL6ZAAA7uXurN9FIpYyUs3OfiIW+Qw==
+espree@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-7.2.0.tgz#1c263d5b513dbad0ac30c4991b93ac354e948d69"
+  integrity sha512-H+cQ3+3JYRMEIOl87e7QdHX70ocly5iW4+dttuR8iYSPr/hXKFb+7dBsZ7+u1adC4VrnPlTkv0+OwuPnDop19g==
   dependencies:
-    acorn "^7.2.0"
+    acorn "^7.3.1"
     acorn-jsx "^5.2.0"
-    eslint-visitor-keys "^1.2.0"
+    eslint-visitor-keys "^1.3.0"
 
 esprima@^4.0.0, esprima@^4.0.1:
   version "4.0.1"
@@ -2190,15 +2217,6 @@ extend@~3.0.2:
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
 
-external-editor@^3.0.3:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-3.1.0.tgz#cb03f740befae03ea4d283caed2741a83f335495"
-  integrity sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==
-  dependencies:
-    chardet "^0.7.0"
-    iconv-lite "^0.4.24"
-    tmp "^0.0.33"
-
 extglob@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/extglob/-/extglob-2.0.4.tgz#ad00fe4dc612a9232e8718711dc5cb5ab0285543"
@@ -2264,7 +2282,7 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
-figures@^3.0.0, figures@^3.2.0:
+figures@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-3.2.0.tgz#625c18bd293c604dc4a8ddb2febf0c88341746af"
   integrity sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==
@@ -2413,6 +2431,11 @@ functional-red-black-tree@^1.0.1:
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
 
+gar@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/gar/-/gar-1.0.4.tgz#f777bc7db425c0572fdeb52676172ca1ae9888b8"
+  integrity sha512-w4n9cPWyP7aHxKxYHFQMegj7WIAsL/YX/C4Bs5Rr8s1H9M1rNtRWRsw+ovYMkXDQ5S4ZbYHsHAPmevPjPgw44w==
+
 gensync@^1.0.0-beta.1:
   version "1.0.0-beta.1"
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.1.tgz#58f4361ff987e5ff6e1e7a210827aa371eaac269"
@@ -2422,6 +2445,14 @@ get-caller-file@^2.0.1:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
+
+get-folder-size@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/get-folder-size/-/get-folder-size-2.0.1.tgz#3fe0524dd3bad05257ef1311331417bcd020a497"
+  integrity sha512-+CEb+GDCM7tkOS2wdMKTn9vU7DgnKUTuDlehkNJKNSovdCOVxs14OfKCk4cvSaR3za4gj+OBdl9opPN9xrJ0zA==
+  dependencies:
+    gar "^1.0.4"
+    tiny-each-async "2.0.3"
 
 get-own-enumerable-property-symbols@^3.0.0:
   version "3.0.2"
@@ -2663,7 +2694,7 @@ husky@^4.2.5:
     slash "^3.0.0"
     which-pm-runs "^1.0.0"
 
-iconv-lite@0.4.24, iconv-lite@^0.4.24:
+iconv-lite@0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -2728,25 +2759,6 @@ inherits@2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
-
-inquirer@^7.0.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-7.1.0.tgz#1298a01859883e17c7264b82870ae1034f92dd29"
-  integrity sha512-5fJMWEmikSYu0nv/flMc475MhGbB7TSPd/2IpFV4I4rMklboCH2rQjYY5kKiYGHqUF9gvaambupcJFFG9dvReg==
-  dependencies:
-    ansi-escapes "^4.2.1"
-    chalk "^3.0.0"
-    cli-cursor "^3.1.0"
-    cli-width "^2.0.0"
-    external-editor "^3.0.3"
-    figures "^3.0.0"
-    lodash "^4.17.15"
-    mute-stream "0.0.8"
-    run-async "^2.4.0"
-    rxjs "^6.5.3"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-    through "^2.3.6"
 
 ip-regex@^2.1.0:
   version "2.1.0"
@@ -3868,11 +3880,6 @@ ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-mute-stream@0.0.8:
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
-  integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
-
 mv@~2:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/mv/-/mv-2.1.1.tgz#ae6ce0d6f6d5e0a4f7d893798d03c1ea9559b6a2"
@@ -4105,11 +4112,6 @@ optionator@^0.9.1:
     prelude-ls "^1.2.1"
     type-check "^0.4.0"
     word-wrap "^1.2.3"
-
-os-tmpdir@~1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
-  integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
 
 p-each-series@^2.1.0:
   version "2.1.0"
@@ -4617,17 +4619,12 @@ rsvp@^4.8.4:
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.5.tgz#c8f155311d167f68f21e168df71ec5b083113734"
   integrity sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==
 
-run-async@^2.4.0:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.1.tgz#8440eccf99ea3e70bd409d49aab88e10c189a455"
-  integrity sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==
-
 run-parallel@^1.1.9:
   version "1.1.9"
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.1.9.tgz#c9dd3a7cf9f4b2c4b6244e173a6ed866e61dd679"
   integrity sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==
 
-rxjs@^6.5.3, rxjs@^6.5.5:
+rxjs@^6.5.5:
   version "6.5.5"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.5.tgz#c5c884e3094c8cfee31bf27eb87e54ccfc87f9ec"
   integrity sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==
@@ -5133,17 +5130,15 @@ throat@^5.0.0:
   resolved "https://registry.yarnpkg.com/throat/-/throat-5.0.0.tgz#c5199235803aad18754a667d659b5e72ce16764b"
   integrity sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==
 
-through@^2.3.6, through@^2.3.8:
+through@^2.3.8:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
 
-tmp@^0.0.33:
-  version "0.0.33"
-  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
-  integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
-  dependencies:
-    os-tmpdir "~1.0.2"
+tiny-each-async@2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-each-async/-/tiny-each-async-2.0.3.tgz#8ebbbfd6d6295f1370003fbb37162afe5a0a51d1"
+  integrity sha1-jru/1tYpXxNwAD+7NxYq/loKUdE=
 
 tmpl@1.0.x:
   version "1.0.4"


### PR DESCRIPTION
JupiterOne does not charge for `Finding` entities, and they are part of the default query used in the Alerts app for showing vulns/findings.

`CONTAINS` is the standard J1 has for containment.

We are adopting `GENERATED` as a more intuitive name than `IDENTIFIED`. Scanners generate findings when they identify a vulnerability.

cc/ @mikhail-golovinov-feroot 