### PR TITLE
Remove option to create target host

### DIFF
--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -23,18 +23,14 @@ copy the key to use in the integration.
 
 The following entity resources are ingested when the integration runs:
 
-| Resources                           | \_type of the Entity       | \_class of the Entity |
-| ----------------------------------- | -------------------------- | --------------------- |
-| User                                | `feroot_user`              | `User`                |
-| User Group                          | `feroot_user_group`        | `UserGroup`           |
-| Project Folder                      | `feroot_project_folder`    | `Group`               |
-| Inspector Project                   | `feroot_project`           | `Project`             |
-| PageGuard Project                   | `feroot_pageguard_project` | `Project`             |
-| Alert                               | `feroot_alert`             | `Finding`             |
-| Target Host [\*](#target-host-note) | `host`                     | `Host`                |
-
-<a name="target-host-note">\*</a>`Target Host` entities are generated only if
-`createTargetHosts` configuration option is turned on.
+| Resources         | \_type of the Entity       | \_class of the Entity |
+| ----------------- | -------------------------- | --------------------- |
+| User              | `feroot_user`              | `User`                |
+| User Group        | `feroot_user_group`        | `UserGroup`           |
+| Project Folder    | `feroot_project_folder`    | `Group`               |
+| Inspector Project | `feroot_project`           | `Project`             |
+| PageGuard Project | `feroot_pageguard_project` | `Project`             |
+| Alert             | `feroot_alert`             | `Finding`             |
 
 ### Relationships
 

--- a/src/instanceConfigFields.ts
+++ b/src/instanceConfigFields.ts
@@ -5,9 +5,6 @@ const instanceConfigFields: IntegrationInstanceConfigFieldMap = {
     type: 'string',
     mask: true,
   },
-  createTargetHosts: {
-    type: 'boolean',
-  },
   includeResolvedAlerts: {
     type: 'boolean',
   },

--- a/src/steps/fetchProjects.test.ts
+++ b/src/steps/fetchProjects.test.ts
@@ -28,16 +28,11 @@ describe('Projects fetching', () => {
       },
     ];
 
-    const { client, context } = createContextMocks(
-      <APIClient>{
-        async getProjects(iteratee) {
-          for (let item of items) await iteratee(item);
-        },
+    const { client, context } = createContextMocks(<APIClient>{
+      async getProjects(iteratee) {
+        for (let item of items) await iteratee(item);
       },
-      {
-        createTargetHosts: false,
-      },
-    );
+    });
 
     await step.executionHandler(context);
 
@@ -88,7 +83,6 @@ describe('Projects fetching', () => {
           targetFilterKeys: [['_class', 'hostname']],
           targetEntity: {
             _class: 'Host',
-            _type: 'host',
             hostname: 'www.feroot.com',
             displayName: 'www.feroot.com',
           },
@@ -107,7 +101,6 @@ describe('Projects fetching', () => {
           targetFilterKeys: [['_class', 'hostname']],
           targetEntity: {
             _class: 'Host',
-            _type: 'host',
             hostname: 'www.google.com',
             displayName: 'www.google.com',
           },
@@ -133,57 +126,6 @@ describe('Projects fetching', () => {
         _fromEntityKey: 'project-uuid-2',
         _toEntityKey: 'pg:pageguard-uuid-1',
         displayName: 'CONTAINS',
-      },
-    ]);
-  });
-
-  test('creates target hosts if configured', async () => {
-    let items: FerootProject[] = [
-      {
-        id: 'abc',
-        name: 'name-1',
-        serviceUuid: 'service-uuid-1',
-        status: 1,
-        urls: ['https://www.feroot.com'],
-        uuid: 'project-uuid-1',
-      },
-    ];
-
-    const { client, context } = createContextMocks(
-      <APIClient>{
-        async getProjects(iteratee) {
-          for (let item of items) await iteratee(item);
-        },
-      },
-      {
-        createTargetHosts: true,
-      },
-    );
-
-    await step.executionHandler(context);
-
-    expect(client.getProjects).toBeCalledTimes(1);
-
-    expect(context.jobState.collectedEntities.length).toBe(1);
-    expect(context.jobState.collectedRelationships).toMatchObject([
-      {
-        _class: 'MONITORS',
-        _mapping: {
-          relationshipDirection: 'FORWARD',
-          sourceEntityKey: 'project-uuid-1',
-          targetFilterKeys: [['_class', 'hostname']],
-          targetEntity: {
-            _class: 'Host',
-            _type: 'host',
-            hostname: 'www.feroot.com',
-            displayName: 'www.feroot.com',
-          },
-          skipTargetCreation: false,
-        },
-        displayName: 'MONITORS',
-        _key:
-          'project-uuid-1|monitors|FORWARD:_class=Host:hostname=www.feroot.com',
-        _type: 'feroot_project_monitors_host',
       },
     ]);
   });

--- a/src/steps/fetchProjects.ts
+++ b/src/steps/fetchProjects.ts
@@ -59,18 +59,17 @@ const step: IntegrationStep<IntegrationConfig> = {
       await jobState.addRelationship(
         createIntegrationRelationship({
           _class: 'MONITORS',
+          _type: 'feroot_project_monitors_host',
           _mapping: {
             relationshipDirection: RelationshipDirection.FORWARD,
-            sourceEntityType: 'feroot_project',
             sourceEntityKey: project.uuid,
             targetFilterKeys: [['_class', 'hostname']],
             targetEntity: {
               _class: 'Host',
-              _type: 'host',
               hostname: hostname,
               displayName: hostname,
             },
-            skipTargetCreation: !instance.config.createTargetHosts,
+            skipTargetCreation: true,
           },
         }),
       );

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,11 +11,6 @@ export interface IntegrationConfig extends IntegrationInstanceConfig {
   ferootApiKey: string;
 
   /**
-   * Indicates whether monitoring hosts should be created if not present in J1 workspace
-   */
-  createTargetHosts?: boolean;
-
-  /**
    * Indicates whether to preserve entities for resolved alerts or to remove all resolved alerts
    * from the graph
    */


### PR DESCRIPTION
This changes the mapping of Project to Host to set `skipTargetCreation: true` always.

The Carbon Black integration [creates a mapped relationship between the sensor agent and a  target entity of `_type: 'user_endpoint'`](https://github.com/JupiterOne/graph-cbdefense/blob/070a10ae2b5f98260b6f90cd8a0615831a01cc8c/src/converters.ts#L296). This supposes that Carbon Black is running on something in the hands of a user and not, for example, a `_type: 'aws_instance'`. If it were running on an EC2 instance, it wouldn't map to it.

In this case, it is likely that the Project is scanning something running as a server, so it would be good to relate to the existing `aws_instance` (for example). And yet, if the Feroot customer is not ingesting any infrastructure, or their servers are on-prem, these changes will prevent any `Host` from being created, so that a query like `find Host` will answer nothing. I'm inclined to think we should encourage the customer to ingest their infrastructure, even if it's [a simple bulk upload script](https://github.com/JupiterOne/jupiterone-client-nodejs#examples).

@erkangz what are your thoughts about this?

cc/ @mikhail-golovinov-feroot 