### PR TITLE
Use Application entity instead of Host in fetchProjects step

### DIFF
--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -23,18 +23,15 @@ copy the key to use in the integration.
 
 The following entity resources are ingested when the integration runs:
 
-| Resources                           | \_type of the Entity       | \_class of the Entity |
-| ----------------------------------- | -------------------------- | --------------------- |
-| User                                | `feroot_user`              | `User`                |
-| User Group                          | `feroot_user_group`        | `UserGroup`           |
-| Project Folder                      | `feroot_project_folder`    | `Group`               |
-| Inspector Project                   | `feroot_project`           | `Project`             |
-| PageGuard Project                   | `feroot_pageguard_project` | `Project`             |
-| Alert                               | `feroot_alert`             | `Finding`             |
-| Target Host [\*](#target-host-note) | `host`                     | `Host`                |
-
-<a name="target-host-note">\*</a>`Target Host` entities are generated only if
-`createTargetHosts` configuration option is turned on.
+| Resources         | \_type of the Entity       | \_class of the Entity |
+| ----------------- | -------------------------- | --------------------- |
+| User              | `feroot_user`              | `User`                |
+| User Group        | `feroot_user_group`        | `UserGroup`           |
+| Project Folder    | `feroot_project_folder`    | `Group`               |
+| Inspector Project | `feroot_project`           | `Project`             |
+| PageGuard Project | `feroot_pageguard_project` | `Project`             |
+| Alert             | `feroot_alert`             | `Finding`             |
+| Target Domain     | `web_app_domain`           | `Application`         |
 
 ### Relationships
 
@@ -44,7 +41,7 @@ The following relationships are created/mapped:
 | ----------------------- | ------------- | -------------------------- |
 | `feroot_user_group`     | **HAS**       | `feroot_user`              |
 | `feroot_user_group`     | **HAS**       | `feroot_project_folder`    |
-| `feroot_project`        | **MONITORS**  | `Host`                     |
+| `feroot_project`        | **MONITORS**  | `web_app_domain`           |
 | `feroot_project_folder` | **HAS**       | `feroot_project`           |
 | `feroot_project`        | **CONTAINS**  | `feroot_pageguard_project` |
 | `feroot_project`        | **GENERATED** | `feroot_alert`             |

--- a/src/instanceConfigFields.ts
+++ b/src/instanceConfigFields.ts
@@ -5,9 +5,6 @@ const instanceConfigFields: IntegrationInstanceConfigFieldMap = {
     type: 'string',
     mask: true,
   },
-  createTargetHosts: {
-    type: 'boolean',
-  },
   includeResolvedAlerts: {
     type: 'boolean',
   },

--- a/src/steps/fetchProjects.ts
+++ b/src/steps/fetchProjects.ts
@@ -56,7 +56,6 @@ const step: IntegrationStep<IntegrationConfig> = {
   types: [
     'feroot_project',
     'feroot_project_folder_has_project',
-    'feroot_project_monitors_host',
     'feroot_project_contains_pageguard_project',
     'web_app_domain',
     'feroot_project_monitors_web_app_domain',

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,11 +11,6 @@ export interface IntegrationConfig extends IntegrationInstanceConfig {
   ferootApiKey: string;
 
   /**
-   * Indicates whether monitoring hosts should be created if not present in J1 workspace
-   */
-  createTargetHosts?: boolean;
-
-  /**
    * Indicates whether to preserve entities for resolved alerts or to remove all resolved alerts
    * from the graph
    */


### PR DESCRIPTION
Use `Application` entity with `web_app_domain` type instead of `Host` entity. Remove the `createTargetHosts` configuration parameter.